### PR TITLE
Adding ports check

### DIFF
--- a/ch01/cmdline.py
+++ b/ch01/cmdline.py
@@ -15,9 +15,10 @@ cmd = "ssh_mine " + args.servername
 if args.flag:
     cmd += " --save_session"
 
-cmd += " -p " 
-for port in args.ports:
-    cmd +=  port + " "
+if args.ports:
+    cmd += " -p " 
+    for port in args.ports:
+        cmd +=  port + " "
 
 print(cmd)
 


### PR DESCRIPTION
Absence of this check makes script iterate through NoneType:

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant/ch01$ ./cmdline.py -s my_server
Namespace(flag=False, ports=None, servername='my_server')
Traceback (most recent call last):
  File "./cmdline.py", line 19, in <module>
    for port in args.ports:
TypeError: 'NoneType' object is not iterable
```
